### PR TITLE
feat: add host management CLI and TTY/remote command support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,103 +10,100 @@ SSH Manager is a Terminal User Interface (TUI) application built with Textual fo
 
 ### Installation
 ```bash
-pip install -e .
+pip install -e .              # Install in editable mode
+pip install -e ".[dev]"       # Install with dev dependencies (pytest, etc.)
 ```
 
 ### Run Tests
 ```bash
-pytest
+pytest                                    # Run all tests
+pytest tests/unit/                        # Run only unit tests
+pytest tests/unit/test_ssh_configs.py     # Run a single test file
+pytest -m unit                            # Run tests by marker
+pytest -m "not slow and not docker"       # Exclude slow/docker tests (default behavior)
+pytest -m docker                          # Run Docker-dependent tests
+pytest --no-cov                           # Skip coverage for faster runs
 ```
+
+Test markers: `unit`, `integration`, `ui`, `e2e`, `slow`, `ssh`, `docker`, `snapshot`
+
+Slow and docker tests are skipped by default. Use `-m docker` or `-m slow` to include them.
 
 ### Run Application
 ```bash
-# Launch main TUI interface
-mssh
-
-# Initialize from ~/.ssh/config
-mssh init
-
-# Open SSH config editor
-mssh config
-
-# Quick connect to known host (opens in new terminal)
-mssh <host-alias>
-
-# Connect with custom parameters (direct shell mode)
-mssh ssh [user@]host [-p PORT]
-
-# With optional log level
-mssh --log-level debug
+mssh                           # Launch main TUI interface
+mssh init                      # Initialize from ~/.ssh/config
+mssh config                    # Open SSH config editor
+mssh <host-alias>              # Quick connect to known host (opens in new terminal)
+mssh ssh [user@]host [-p PORT] # Connect with custom parameters (direct shell mode)
+mssh --log-level debug         # With debug logging
 ```
 
 ### Test Environment
-A Docker-based test environment is available in the `tests/` directory:
+Docker-based SSH test server in `tests/`:
 ```bash
-cd tests
-docker compose up -d      # Start test SSH server on localhost:2222
-docker compose down       # Stop test server
+cd tests && docker compose up -d    # Start test SSH server on localhost:2222
+cd tests && docker compose down     # Stop test server
 ```
 
 ## Architecture
 
 ### Entry Point
-- `ssh_manager/app.py` - Main CLI entry point with argparse-based command routing
+- `ssh_manager/app.py` - `main()` with argparse-based command routing. Two Textual apps: `SSHManagerApp` (host management) and `EditorSSHConfigApp` (config editor)
 
-### Core Components
+### Core Modules
 
 **Configuration Layer** (`ssh_manager/utils/ssh_configs.py`)
-- `HostConfig` - Pydantic model for SSH host configuration
-- `parse_text_to_configs()` - Parser for SSH config file format
-- `load_ssh_config_file()` - Load from `~/.ssh/config`
-- `load_known_ssh_hosts()` - Load from `~/.mssh/config.json` cache
-- `update_host_config()` - Persist configuration to JSON cache
-- `HOST_CONFIG_CACHE` - In-memory cache for host configurations
+- `HostConfig` - Pydantic model with SSH params + port forwarding rules, `get_ssh_command()` generates subprocess args
+- `parse_text_to_configs()` / `parse_ssh_command()` - Parsers for SSH config text and CLI arguments
+- Dual storage: `~/.ssh/config` (source of truth) ↔ `~/.mssh/config.json` (runtime cache)
+- `HOST_CONFIG_CACHE` - In-memory dict for fast lookup
 
 **SSH Connection Layer** (`ssh_manager/utils/ssh_util.py`)
-- `SSHConnection` - Pure subprocess-based SSH connection with monitoring thread
-- `create_persistent_ssh_connection()` - Create and cache persistent connections
-- `SSHConnectionManager` - Thread-safe global connection registry (`_connection_manager`)
-- `test_ssh_key_auth()` - Test SSH key authentication using BatchMode
-- `upload_ssh_key_with_ssh()` - Upload public key to remote host
+- Pure subprocess-based SSH (no paramiko/external libs), uses native `ssh` binary
+- `SSHConnection` - Wraps `subprocess.Popen` with daemon monitor thread
+- `SSHConnectionManager` - Thread-safe registry (`RLock`) via global `_connection_manager`
+- `test_ssh_key_auth()` / `upload_ssh_key_with_ssh()` - Key auth test and upload workflow
 
-**UI Layer** (Textual-based)
-- `screens/main_screens.py` - `SSHManageMainScreen` - Split-pane interface (host list + config editor)
-- `screens/edit_ssh_config.py` - Dual-pane editor for `~/.ssh/config`
-- `screens/ssh_conn_screens.py` - Connection management screen
-- `widgets/host_list.py` - `HostListItem` for host list display
-- `widgets/editor.py` - `HostConfigEditor` with SSH syntax auto-completion
-- `widgets/proxy_table.py` - `ProxyTableWidget` for port forwarding rules
-- `widgets/add_forward_modal.py` - Modal for adding port forwarding
+**Terminal Utilities** (`ssh_manager/utils/terminal_util.py`)
+- `open_new_terminal()` - Cross-platform new terminal window (Windows `cmd`, Linux gnome-terminal/xterm)
+- `clear_terminal()` - Decorator for screen clearing
 
-**TUI Key Bindings**
-- `ESC` - Quit application
-- `C` - Connect to selected host
-- `Enter` - Connect to selected host (from main screen)
+**UI Layer** (`ssh_manager/screens/`, `ssh_manager/widgets/`)
+- `SSHManageMainScreen` - Split-pane: host list (left) + config editor (right)
+- `EditSSHConfigScreen` - Dual-pane `~/.ssh/config` editor
+- `SSHConnScreen` - Active connection with port forwarding management
+- `HostListItem` / `HostConfigEditor` / `ProxyTableWidget` / `AddForwardModal` - Reusable widgets
+
+**Vendored** (`ssh_manager/vendor/textual_textarea/`) - Bundled text editor component with autocomplete
+
+### Key Bindings (TUI)
+- `ESC` - Quit | `C` / `Enter` - Connect to selected host
 
 ### Data Flow
 
-1. **Initialization**: `mssh init` reads `~/.ssh/config` → `parse_text_to_configs()` → `~/.mssh/config.json`
-2. **Runtime**: `mssh` loads `~/.mssh/config.json` → `HOST_CONFIG_CACHE` → TUI display
+1. **Init**: `mssh init` → `~/.ssh/config` → `parse_text_to_configs()` → `~/.mssh/config.json`
+2. **Runtime**: `mssh` → `~/.mssh/config.json` → `HOST_CONFIG_CACHE` → TUI display
 3. **Connection**: TUI action → `test_ssh_key_auth()` → prompt if failed → `upload_ssh_key_with_ssh()` → `SSHConnection` subprocess
 4. **Persistence**: Editor changes → `parse_text_to_configs()` → `update_host_config()` → JSON cache
 
-### Key Design Patterns
-
-- **Pydantic models** for configuration validation and serialization
-- **Thread-safe connection manager** (`SSHConnectionManager`) with RLock for concurrent access
-- **Dual parsing**: SSH config file format (text) ↔ JSON cache (internal)
-- **Pure subprocess SSH**: No external SSH libraries, uses native ssh binary with daemon monitor threads
-- **Key authentication workflow**: Test key auth → Prompt user → Upload via ssh command → Retry
+### Design Patterns
+- **Pydantic models** for config validation and serialization
+- **Thread-safe connection manager** with RLock
+- **Dual parsing**: SSH config text format ↔ JSON cache
+- **Pure subprocess SSH**: native `ssh` binary with daemon monitor threads
+- **Key auth workflow**: test → prompt → upload → retry
 
 ## Important Paths
 
-- `~/.ssh/config` - Standard SSH configuration file
-- `~/.mssh/config.json` - Application's host configuration cache
-- `SSH_CONFIG_FILE_PATH` and `HOST_CACHE_FILE_PATH` in `ssh_configs.py`
+- `~/.ssh/config` - SSH config (source of truth)
+- `~/.mssh/config.json` - App's host cache
+- `SSH_CONFIG_FILE_PATH`, `MSSH_HOME`, `HOST_CACHE_FILE_PATH` in `ssh_configs.py`
 
 ## Dependencies
 
 - `textual` - TUI framework
-- `textual-dev` - Textual development tools
-- `pydantic` - Configuration validation
+- `textual-dev` - Textual dev tools
+- `pydantic` - Config validation
 - `pyperclip` - Clipboard operations
+- Build: `flit` (PEP 517)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,36 +11,22 @@ SSH Manager is a Terminal User Interface (TUI) application built with Textual fo
 ### Installation
 ```bash
 pip install -e .              # Install in editable mode
-pip install -e ".[dev]"       # Install with dev dependencies (pytest, etc.)
 ```
-
-### Run Tests
-```bash
-pytest                                    # Run all tests
-pytest tests/unit/                        # Run only unit tests
-pytest tests/unit/test_ssh_configs.py     # Run a single test file
-pytest -m unit                            # Run tests by marker
-pytest -m "not slow and not docker"       # Exclude slow/docker tests (default behavior)
-pytest -m docker                          # Run Docker-dependent tests
-pytest --no-cov                           # Skip coverage for faster runs
-```
-
-Test markers: `unit`, `integration`, `ui`, `e2e`, `slow`, `ssh`, `docker`, `snapshot`
-
-Slow and docker tests are skipped by default. Use `-m docker` or `-m slow` to include them.
 
 ### Run Application
 ```bash
-mssh                           # Launch main TUI interface
-mssh init                      # Initialize from ~/.ssh/config
-mssh config                    # Open SSH config editor
-mssh <host-alias>              # Quick connect to known host (opens in new terminal)
-mssh ssh [user@]host [-p PORT] # Connect with custom parameters (direct shell mode)
-mssh --log-level debug         # With debug logging
+mssh                                    # Launch main TUI interface
+mssh init [--force]                     # Initialize from ~/.ssh/config
+mssh config                             # Open SSH config editor
+mssh add <host-alias> -c "ssh ..."      # Add host config from SSH command string
+mssh <host-alias>                       # Quick connect to known host (opens in new terminal)
+mssh ssh [user@]host [-p PORT] [-J proxy] [-t] [remote_command]  # Direct shell mode
+mssh --log-level debug                  # With debug logging
+mssh -v                                 # Show version
 ```
 
 ### Test Environment
-Docker-based SSH test server in `tests/`:
+Docker-based SSH test server in `tests/` (see `tests/README.md` for details):
 ```bash
 cd tests && docker compose up -d    # Start test SSH server on localhost:2222
 cd tests && docker compose down     # Stop test server
@@ -49,21 +35,25 @@ cd tests && docker compose down     # Stop test server
 ## Architecture
 
 ### Entry Point
-- `ssh_manager/app.py` - `main()` with argparse-based command routing. Two Textual apps: `SSHManagerApp` (host management) and `EditorSSHConfigApp` (config editor)
+- `ssh_manager/app.py` - `main()` with argparse-based command routing via `handle_init_command()`, `handle_config_command()`, `handle_add_command()`, `handle_ssh_command()`. Two Textual apps: `SSHManagerApp` (host management) and `EditorSSHConfigApp` (config editor)
 
 ### Core Modules
 
 **Configuration Layer** (`ssh_manager/utils/ssh_configs.py`)
-- `HostConfig` - Pydantic model with SSH params + port forwarding rules, `get_ssh_command()` generates subprocess args
+- `HostConfig` - Pydantic model: `host`, `hostname`, `user`, `port`, `local_forwards`, `remote_forwards`, `proxy_command`, `proxy_jump`, `remote_command`, `request_tty`
+  - `get_ssh_command()` generates subprocess args, `to_text()` / `from_text()` for SSH config text format
 - `parse_text_to_configs()` / `parse_ssh_command()` - Parsers for SSH config text and CLI arguments
-- Dual storage: `~/.ssh/config` (source of truth) ↔ `~/.mssh/config.json` (runtime cache)
+- `load_known_ssh_hosts()` / `load_ssh_config_file()` - Load from JSON cache and SSH config file
+- `update_host_config()` / `remove_host_config()` - Mutate cache + persist to JSON
 - `HOST_CONFIG_CACHE` - In-memory dict for fast lookup
+- Dual storage: `~/.ssh/config` (source of truth) ↔ `~/.mssh/config.json` (runtime cache)
 
 **SSH Connection Layer** (`ssh_manager/utils/ssh_util.py`)
 - Pure subprocess-based SSH (no paramiko/external libs), uses native `ssh` binary
-- `SSHConnection` - Wraps `subprocess.Popen` with daemon monitor thread
-- `SSHConnectionManager` - Thread-safe registry (`RLock`) via global `_connection_manager`
+- `SSHConnection` - Extends `subprocess.Popen` with daemon monitor thread for connection health tracking
+- `SSHConnectionManager` - Thread-safe registry (`RLock`) via global singleton `_connection_manager`
 - `test_ssh_key_auth()` / `upload_ssh_key_with_ssh()` - Key auth test and upload workflow
+- `create_persistent_ssh_connection()` / `close_persistent_ssh_connection()` - High-level connection lifecycle with optional key check + upload prompt
 
 **Terminal Utilities** (`ssh_manager/utils/terminal_util.py`)
 - `open_new_terminal()` - Cross-platform new terminal window (Windows `cmd`, Linux gnome-terminal/xterm)
@@ -71,14 +61,28 @@ cd tests && docker compose down     # Stop test server
 
 **UI Layer** (`ssh_manager/screens/`, `ssh_manager/widgets/`)
 - `SSHManageMainScreen` - Split-pane: host list (left) + config editor (right)
-- `EditSSHConfigScreen` - Dual-pane `~/.ssh/config` editor
-- `SSHConnScreen` - Active connection with port forwarding management
-- `HostListItem` / `HostConfigEditor` / `ProxyTableWidget` / `AddForwardModal` - Reusable widgets
+- `EditSSHConfigScreen` - Dual-pane `~/.ssh/config` editor (left: raw config, right: mssh cache)
+- `SSHConnScreen` - Active connection with port forwarding management, ASCII host info table
+- `HostListItem` - List item with connection status indicator (green/red dot)
+- `HostConfigEditor` - Vendored TextEditor with SSH config autocomplete (`ssh_config_completer`)
+- `ProxyManageTable` - Editable DataTable for port forwarding rules (extends `EditableTableWidget`)
+- `AddPortForwardModal` - Modal dialog for adding new port forwarding rules
+- `EditableTableWidget` - Base widget: editable DataTable with inline cell editing via Input
+- `TextEditor` - Simple TextArea wrapper used in config editor screen
 
 **Vendored** (`ssh_manager/vendor/textual_textarea/`) - Bundled text editor component with autocomplete
 
 ### Key Bindings (TUI)
-- `ESC` - Quit | `C` / `Enter` - Connect to selected host
+
+**Main Screen** (`SSHManageMainScreen`):
+- `ESC` - Quit (only when list has focus) | `C` / `Enter` - Connect to selected host
+- `E` - Focus editor | `Ctrl+S` - Save config | `Ctrl+D` - Delete config | `Ctrl+N` - New config
+
+**Connection Screen** (`SSHConnScreen`):
+- `ESC` - Back to main screen
+
+**Port Forward Table** (`ProxyManageTable`):
+- `Ctrl+L` - Add local forward | `Ctrl+R` - Add remote forward | `Ctrl+D` - Delete row
 
 ### Data Flow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ssh_manager"
-version = "0.1.0"
+version = "0.2.0"
 description = "A terminal SSH connection manager with TUI for managing configs, port forwarding, and quick connections"
 requires-python = ">=3.10"
 

--- a/ssh_manager/app.py
+++ b/ssh_manager/app.py
@@ -1,5 +1,7 @@
 import argparse
+import importlib.metadata
 import logging
+import shlex
 
 from textual import events
 from textual.app import App
@@ -94,6 +96,36 @@ def handle_config_command():
     app.run()
 
 
+def handle_add_command(args):
+    """Handle the 'add' subcommand to add a host config from an SSH command string."""
+    # Split command string safely (handles quoted arguments)
+    cmd_parts = shlex.split(args.ssh_command)
+    if not cmd_parts:
+        print("Error: empty command string")
+        return
+
+    # Ensure command starts with 'ssh'
+    if cmd_parts[0] != 'ssh':
+        cmd_parts = ['ssh'] + cmd_parts
+
+    # Parse into HostConfig
+    host_config = parse_ssh_command(cmd_parts)
+    if not host_config:
+        print(f"Error: failed to parse SSH command: {args.ssh_command}")
+        return
+
+    # Override host alias with user-provided name
+    host_config = host_config.model_copy(update={"host": args.host_alias})
+
+    # Persist and launch TUI with the new config selected
+    update_host_config(host_config)
+    host_configs_map = load_known_ssh_hosts()
+    host_configs = list(host_configs_map.values())
+
+    app = SSHManagerApp(host_configs, selected_config=host_config)
+    app.run()
+
+
 def handle_ssh_command(args):
     """Handle the 'ssh' subcommand for SSH connection management."""
     from ssh_manager.utils.ssh_util import test_ssh_key_auth, upload_ssh_key_with_ssh
@@ -114,6 +146,10 @@ def handle_ssh_command(args):
             ssh_args.extend(['-p', str(args.port)])
         if args.proxy_jump:
             ssh_args.extend(['-J', args.proxy_jump])
+        if args.tty:
+            ssh_args.append('-t')
+        if args.remote_command:
+            ssh_args.append(args.remote_command)
 
         cmd_host_config = parse_ssh_command(['ssh'] + ssh_args)
         if cmd_host_config:
@@ -177,6 +213,11 @@ def main():
 
     # Global options
     parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version=f'{importlib.metadata.version("ssh_manager")} (SSH Manager)'
+    )
+    parser.add_argument(
         "--log-level",
         choices=['debug', 'info', 'warning', 'error'],
         default="warning",
@@ -207,6 +248,22 @@ def main():
         help='Open SSH configuration editor'
     )
 
+    # Add subcommand
+    parser_add = subparsers.add_parser(
+        'add',
+        help='Add host config from SSH command'
+    )
+    parser_add.add_argument(
+        'host_alias',
+        help='Host alias name'
+    )
+    parser_add.add_argument(
+        '-c', '--command',
+        required=True,
+        dest='ssh_command',
+        help='SSH command string (e.g. "ssh -p 22 user@host")'
+    )
+
     # SSH subcommand
     parser_ssh = subparsers.add_parser(
         'ssh',
@@ -225,6 +282,18 @@ def main():
     parser_ssh.add_argument(
         '-J', '--proxy-jump',
         help='ProxyJump host for connection'
+    )
+    parser_ssh.add_argument(
+        '-t', '--tty',
+        action='store_true',
+        default=False,
+        help='Force pseudo-terminal allocation'
+    )
+    parser_ssh.add_argument(
+        'remote_command',
+        nargs='?',
+        default=None,
+        help='Remote command to execute after connection'
     )
 
     # Parse arguments with known args to capture potential host argument
@@ -279,6 +348,9 @@ def main():
     elif args.command == 'config':
         handle_config_command()
         return
+    elif args.command == 'add':
+        handle_add_command(args)
+        return
     elif args.command == 'ssh':
         handle_ssh_command(args)
         return
@@ -308,7 +380,9 @@ def main():
     ssh_args = argparse.Namespace(
         target=None,
         port=None,
-        proxy_jump=None
+        proxy_jump=None,
+        tty=False,
+        remote_command=None
     )
 
     if unknown_args:

--- a/ssh_manager/app.py
+++ b/ssh_manager/app.py
@@ -149,7 +149,7 @@ def handle_ssh_command(args):
         if args.tty:
             ssh_args.append('-t')
         if args.remote_command:
-            ssh_args.append(args.remote_command)
+            ssh_args.extend(args.remote_command)
 
         cmd_host_config = parse_ssh_command(['ssh'] + ssh_args)
         if cmd_host_config:
@@ -291,7 +291,7 @@ def main():
     )
     parser_ssh.add_argument(
         'remote_command',
-        nargs='?',
+        nargs=argparse.REMAINDER,
         default=None,
         help='Remote command to execute after connection'
     )

--- a/ssh_manager/utils/ssh_configs.py
+++ b/ssh_manager/utils/ssh_configs.py
@@ -26,6 +26,8 @@ class HostConfig(BaseModel):
     remote_forwards: Dict[str, str] = {}    # Remote port forwarding rules {remote_port: local_host:local_port}
     proxy_command: Optional[str] = None     # ProxyCommand for SSH connection
     proxy_jump: Optional[str] = None        # ProxyJump host for SSH connection
+    remote_command: Optional[str] = None    # RemoteCommand to execute on remote host
+    request_tty: bool = False               # RequestTTY: force TTY allocation (-t flag)
     
     def get_ssh_command(self, extra_options: List[str] = None) -> List[str]:
         """Generate SSH command arguments list for this host configuration.
@@ -88,7 +90,17 @@ class HostConfig(BaseModel):
             ssh_command_args.extend(["-J", proxy_jump])
 
         # Combine base command with port forwarding arguments
-        return ssh_command_args + port_forwarding_commands
+        result = ssh_command_args + port_forwarding_commands
+
+        # Add TTY allocation flag if requested
+        if self.request_tty:
+            result.append("-t")
+
+        # Append remote command at the end
+        if self.remote_command:
+            result.append(self.remote_command)
+
+        return result
 
     def update_config(self, config: "HostConfig"):
         """Update current configuration with values from another HostConfig.
@@ -139,6 +151,14 @@ class HostConfig(BaseModel):
         if self.proxy_jump:
             texts.append(f"{indent}# Through host to reach target\n")
             texts.append(f"{indent}ProxyJump {self.proxy_jump}\n")
+
+        # Add TTY allocation request if enabled
+        if self.request_tty:
+            texts.append(f"{indent}RequestTTY yes\n")
+
+        # Add remote command if specified
+        if self.remote_command:
+            texts.append(f"{indent}RemoteCommand {self.remote_command}\n")
 
         return "".join(texts)
     
@@ -304,6 +324,14 @@ def parse_text_to_configs(text: str) -> Dict[str, HostConfig]:
             # ProxyJump host alias
             current_config['proxy_jump'] = values[0]
 
+        elif current_host and key == 'remotecommand':
+            # RemoteCommand: command to execute on the remote host
+            current_config['remote_command'] = " ".join(values).strip('"').strip("'")
+
+        elif current_host and key == 'requesttty':
+            # RequestTTY: force TTY allocation (yes/force → True)
+            current_config['request_tty'] = values[0].lower() in ('yes', 'force')
+
         elif current_host:
             # Handle other SSH config options (hostname, user, etc.)
             current_config[key] = values[0]
@@ -371,11 +399,15 @@ def parse_ssh_command(cmd_args: Sequence[str]) -> Optional[HostConfig]:
 
     parser.add_argument("-p", "--port", type=int, required=False, default=22)
     parser.add_argument("-n", "--name", type=str, required=False, default="")
+    parser.add_argument("-t", action="store_true", default=False, dest='request_tty')
 
     try:
-        args, _ = parser.parse_known_args(cmd_args)
+        args, remaining = parser.parse_known_args(cmd_args)
     except SystemExit:
         return None
+
+    # Remaining args after known options are the remote command
+    remote_command = " ".join(remaining).strip('"').strip("'") if remaining else None
 
     # Load known host configurations from cache
     host_configs_map = load_known_ssh_hosts()
@@ -436,7 +468,9 @@ def parse_ssh_command(cmd_args: Sequence[str]) -> Optional[HostConfig]:
         user=user,
         port=args.port,
         local_forwards=local_forwards,
-        remote_forwards=remote_forwards
+        remote_forwards=remote_forwards,
+        remote_command=remote_command,
+        request_tty=args.request_tty,
     )
 
     # Merge with known configuration if exists (prioritize command line arguments)

--- a/ssh_manager/widgets/editor.py
+++ b/ssh_manager/widgets/editor.py
@@ -54,9 +54,14 @@ def ssh_config_completer(word: str, line_context: str = "") -> Sequence[tuple[Re
         'Pr': ('ProxyJump', 'ProxyCommand ssh -W %h:%p',),
         'P': ('Port', 'Password'),
 
+        'RemoteF': ('RemoteForward',),
+        'RemoteC': ('RemoteCommand',),
+        'Rem': ('RemoteForward', 'RemoteCommand'),
+        'Req': ('RequestTTY',),
+        'R': ('RemoteForward', 'RemoteCommand', 'RequestTTY'),
+
         'U': ('User',),
         'L': ('LocalForward',),
-        'R': ('RemoteForward',),
         'l': ('localhost', ),
         '1': ('127.0.0.1', '192.168.'),
         '12': ('127.0.0.1', ),


### PR DESCRIPTION
- Add 'mssh add' subcommand to create host configs from SSH command strings
- Add '-v/--version' flag via importlib.metadata, bump to 0.2.0
- Add '-t/--tty' flag and multi-word remote command support in 'mssh ssh'
- Extend HostConfig with remote_command and request_tty fields
- Parse and emit RemoteCommand/RequestTTY SSH config directives
- Update editor autocomplete with RemoteCommand, RequestTTY, RemoteForward
- Audit and fix CLAUDE.md to match actual codebase